### PR TITLE
change response status method call

### DIFF
--- a/src/HttpMiddleware/HttpMetricsMiddleware.php
+++ b/src/HttpMiddleware/HttpMetricsMiddleware.php
@@ -28,7 +28,7 @@ class HttpMetricsMiddleware
         $endTime = microtime(true);
 
         $duration = $endTime - $startTime;
-        $this->latencyProfiler->writeMetrics(Prometheus::bag(), $response->status(), $duration);
+        $this->latencyProfiler->writeMetrics(Prometheus::bag(), $response->getStatusCode(), $duration);
 
         return $response;
     }


### PR DESCRIPTION
Метод status() тянется из трейта ResponseTrait, который наследуется классом Illuminate\Http\Response.

Столкнулся с ошибкой отсутсвия метода при попытке скачать файл методом download() в Laravel, который возвращает Symfony\Component\HttpFoundation\Response, и он не использует вышеупомянутый трейт.

Предлагаю использовать метод getStatusCode(), так как он присутсвует в обоих классах Response (Illuminate\Http\Response наследуется от Symfony\Component\HttpFoundation\Response).

На первый взгляд, поломаться ничего не должно. Метод status() лишь проксирует запрос к getStatusCode().

Благодарю за внимание.