### PR TITLE
fix for apcu-ng

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": ">=8.1",
         "psr/http-message": "^1.0",
         "guzzlehttp/guzzle": "^7.0",
-        "ensi/laravel-prometheus": "^1.0.6"
+        "ensi/laravel-prometheus": "^1.0.8"
     },
     "require-dev": {
         "franzl/studio": "^0.16.0",

--- a/src/Guzzle/GuzzleMiddleware.php
+++ b/src/Guzzle/GuzzleMiddleware.php
@@ -42,9 +42,7 @@ class GuzzleMiddleware
         $profiler = resolve(LatencyProfiler::class);
         $profiler->addAsyncTimeQuant($type, $start, $end);
 
-        $labels = [
-            'host' => $host,
-        ];
+        $labels = [$host];
 
         Prometheus::update('http_client_seconds_total', $end - $start, $labels);
 


### PR DESCRIPTION
**Выпускать релиз пока не нужно тут** пока вот [тут](https://github.com/ensi-platform/laravel-prometheus/pull/6) не будет выпущен релиз. 
Как будет выпущен в пакете прометеус релиз, нужно в данном пакете обновить пакет прометеуса и только потом выпускать релиз

Протестировано. Тестирование проводилось и на fpm и на swoole сервисах
